### PR TITLE
Project Initialisation

### DIFF
--- a/BrowserSwitcher.Mediator/BrowserSwitcher.Mediator.csproj
+++ b/BrowserSwitcher.Mediator/BrowserSwitcher.Mediator.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" Version="3.17.3" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.38.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.36.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="..\BrowserSwitcher\**\*.proto" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+</Project>

--- a/BrowserSwitcher.Mediator/Program.cs
+++ b/BrowserSwitcher.Mediator/Program.cs
@@ -1,0 +1,26 @@
+﻿using Grpc.Net.Client;
+using System;
+using System.Threading.Tasks;
+
+namespace BrowserSwitcher.Mediator
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            if(args.Length > 0)
+            {
+                await DoIt(args[0]);
+            }
+        }
+
+        public static async Task DoIt(string myVal)
+        {
+            using var channel = GrpcChannel.ForAddress("http://localhost:5000");
+            var client = new Greeter.GreeterClient(channel);
+            var reply = await client.SayHelloAsync(
+                new HelloRequest { Name = myVal 
+            });
+        }
+    }
+}

--- a/BrowserSwitcher.Mediator/Properties/launchSettings.json
+++ b/BrowserSwitcher.Mediator/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "WSL 2": {
+      "commandName": "WSL2",
+      "environmentVariables": {},
+      "distributionName": ""
+    },
+    "BrowserSwitcher.Mediator": {
+      "commandName": "Project",
+      "commandLineArgs": "\"test this out 1\""
+    }
+  }
+}

--- a/BrowserSwitcher.sln
+++ b/BrowserSwitcher.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31512.422
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BrowserSwitcher", "BrowserSwitcher\BrowserSwitcher.csproj", "{CBFF4150-64CA-44EA-BB32-27CCF91176CC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BrowserSwitcher.Mediator", "BrowserSwitcher.Mediator\BrowserSwitcher.Mediator.csproj", "{05844E34-0686-4F9B-98FD-F4BDA6A49061}"
+	ProjectSection(ProjectDependencies) = postProject
+		{CBFF4150-64CA-44EA-BB32-27CCF91176CC} = {CBFF4150-64CA-44EA-BB32-27CCF91176CC}
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CBFF4150-64CA-44EA-BB32-27CCF91176CC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CBFF4150-64CA-44EA-BB32-27CCF91176CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CBFF4150-64CA-44EA-BB32-27CCF91176CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CBFF4150-64CA-44EA-BB32-27CCF91176CC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{05844E34-0686-4F9B-98FD-F4BDA6A49061}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{05844E34-0686-4F9B-98FD-F4BDA6A49061}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{05844E34-0686-4F9B-98FD-F4BDA6A49061}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{05844E34-0686-4F9B-98FD-F4BDA6A49061}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8128B586-6F6A-4971-B942-603E1D7F7FE7}
+	EndGlobalSection
+EndGlobal

--- a/BrowserSwitcher/BrowserSwitcher.csproj
+++ b/BrowserSwitcher/BrowserSwitcher.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Grpc.AspNetCore" Version="2.36.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="5.0.1" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <Protobuf Include="Protos\greet.proto" GrpcServices="Server" />
+  </ItemGroup>
+
+</Project>

--- a/BrowserSwitcher/Program.cs
+++ b/BrowserSwitcher/Program.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace BrowserSwitcher
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        // Additional configuration is required to successfully run gRPC on macOS.
+        // For instructions on how to configure Kestrel and gRPC clients on macOS, visit https://go.microsoft.com/fwlink/?linkid=2099682
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .UseWindowsService()
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder
+                        .UseStartup<Startup>()
+                    ;
+                })
+                ;
+    }
+}

--- a/BrowserSwitcher/Properties/launchSettings.json
+++ b/BrowserSwitcher/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "CodeRed.Switcher": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/BrowserSwitcher/Protos/greet.proto
+++ b/BrowserSwitcher/Protos/greet.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+option csharp_namespace = "BrowserSwitcher";
+
+package greet;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (google.protobuf.Empty);
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}

--- a/BrowserSwitcher/Services/GreeterService.cs
+++ b/BrowserSwitcher/Services/GreeterService.cs
@@ -1,0 +1,24 @@
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace BrowserSwitcher
+{
+    public class GreeterService : Greeter.GreeterBase
+    {
+        private readonly ILogger<GreeterService> _logger;
+        public GreeterService(ILogger<GreeterService> logger)
+        {
+            _logger = logger;
+        }
+
+        public override Task<Empty> SayHello(HelloRequest request, ServerCallContext context)
+        {
+            return Task.FromResult(new Empty());
+        }
+    }
+}

--- a/BrowserSwitcher/Startup.cs
+++ b/BrowserSwitcher/Startup.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace BrowserSwitcher
+{
+    public class Startup
+    {
+        // This method gets called by the runtime. Use this method to add services to the container.
+        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddGrpc();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapGrpcService<GreeterService>();
+
+                endpoints.MapGet("/", async context =>
+                {
+                    await context.Response.WriteAsync("Communication with gRPC endpoints must be made through a gRPC client. To learn how to create a client, visit: https://go.microsoft.com/fwlink/?linkid=2086909");
+                });
+            });
+        }
+    }
+}

--- a/BrowserSwitcher/appsettings.Development.json
+++ b/BrowserSwitcher/appsettings.Development.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Grpc": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/BrowserSwitcher/appsettings.json
+++ b/BrowserSwitcher/appsettings.json
@@ -1,0 +1,15 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*",
+  "Kestrel": {
+    "EndpointDefaults": {
+      "Protocols": "Http2"
+    }
+  }
+}


### PR DESCRIPTION
- BrowserSwitcher 
-- Set up application from gRPC server project template
-- Added packages and configuration to support Windows Service installs
-- Amended default proto and service for return type of 'Empty'
- BrowserSwitcher.Mediator
-- Set up application as console app and added gRPC components as needed
-- Configured project file to include proto files from BrowserSwitcher directory (to reduce proto maintenance overhead)
-- Set up app to require commandline args and send first one to server